### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,17 @@ lint-yamllint:
           pip install yamllint
           ./run-tests.sh --lint-yamllint
 
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,21 @@
 name: ci
 
 on:
+
+lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,24 @@ lint-jsonlint:
           npm install jsonlint --global
           ./run-tests.sh --lint-jsonlint
 
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on:
   push:
@@ -32,12 +32,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -48,4 +48,4 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,23 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 7 * * 1'
+    - cron: "0 7 * * 1"
 
 jobs:
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
+
   format-shfmt:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,40 +7,13 @@
 name: ci
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 7 * * 1'
 
-lint-jsonlint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-
-      - name: Lint JSON files
-        run: |
-          npm install jsonlint --global
-          ./run-tests.sh --lint-jsonlint
-
-lint-yamllint:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --lint-yamllint
-
-format-shfmt:
+jobs:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -51,12 +24,6 @@ format-shfmt:
           sudo apt-get install shfmt
           ./run-tests.sh --format-shfmt
 
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 7 * * 1'
-
-jobs:
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -83,6 +50,34 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-jsonlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint JSON files
+        run: |
+          npm install jsonlint --global
+          ./run-tests.sh --lint-jsonlint
+
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -93,3 +88,19 @@ jobs:
         run: |
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
+
+  lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 This [REANA](http://www.reana.io/) reproducible analysis example provides a
 simple example how to run Dask workflows using Coffea. The example was adapted
 from
-[Coffea Casa
-tutorials](https://github.com/CoffeaTeam/coffea-casa-tutorials/blob/master/examples/example1.ipynb)
+[Coffea Casa tutorials](https://github.com/CoffeaTeam/coffea-casa-tutorials/blob/master/examples/example1.ipynb)
 repository.
 
 ## Analysis structure

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 This [REANA](http://www.reana.io/) reproducible analysis example provides a
 simple example how to run Dask workflows using Coffea. The example was adapted
 from
-[Coffea Casa tutorials](https://github.com/CoffeaTeam/coffea-casa-tutorials/blob/master/examples/example1.ipynb)
+[Coffea Casa
+tutorials](https://github.com/CoffeaTeam/coffea-casa-tutorials/blob/master/examples/example1.ipynb)
 repository.
 
 ## Analysis structure
@@ -56,7 +57,7 @@ will take care of dispatching computations.
 
 The example produces the following MET event-level histogram as an output.
 
-![](https://github.com/user-attachments/assets/e52c2391-626d-4556-90ca-75248516cc95)
+![image](https://github.com/user-attachments/assets/e52c2391-626d-4556-90ca-75248516cc95)
 
 ## Running the example on REANA cloud
 

--- a/reana.yaml
+++ b/reana.yaml
@@ -11,7 +11,7 @@ workflow:
       - name: process
         environment: docker.io/coffeateam/coffea-dask-cc7:0.7.22-py3.10-g7f049
         commands:
-        - python analysis.py
+          - python analysis.py
 outputs:
   files:
     - histogram.png

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,15 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,23 +47,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -68,6 +72,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_jsonlint
@@ -80,6 +85,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -98,6 +104,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-jsonlint) lint_jsonlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -47,12 +47,17 @@ lint_commitlint() {
     fi
 }
 
+lint_jsonlint() {
+    find . -name "*.json" -exec jsonlint -q {} \+
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
 all() {
     lint_commitlint
+    lint_jsonlint
     lint_shellcheck
 }
 
@@ -62,6 +67,7 @@ help() {
     echo "  --all              Perform all checks [default]"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-jsonlint    Check linting of JSON files"
     echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
@@ -75,6 +81,7 @@ case $arg in
 --all) all ;;
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-jsonlint) lint_jsonlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -35,7 +39,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -60,6 +64,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_jsonlint
     lint_shellcheck
@@ -70,6 +75,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-jsonlint    Check linting of JSON files"
@@ -86,6 +92,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-jsonlint) lint_jsonlint ;;
 --lint-shellcheck) lint_shellcheck ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,10 +55,15 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_jsonlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -69,6 +74,7 @@ help() {
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-jsonlint    Check linting of JSON files"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -83,5 +89,6 @@ case $arg in
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-jsonlint) lint_jsonlint ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -55,6 +55,10 @@ lint_jsonlint() {
     find . -name "*.json" -exec jsonlint -q {} \+
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -67,6 +71,7 @@ all() {
     format_shfmt
     lint_commitlint
     lint_jsonlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -74,13 +79,14 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-jsonlint    Check linting of JSON files"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-jsonlint      Check linting of JSON files"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -95,6 +101,7 @@ case $arg in
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-jsonlint) lint_jsonlint ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.